### PR TITLE
Datasource Pathnames too long

### DIFF
--- a/MSTestHacks.Tests/MSTestHacks.Tests.csproj
+++ b/MSTestHacks.Tests/MSTestHacks.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Asserts\ExceptionAssertTests.cs" />
     <Compile Include="RuntimeDataSource\ComplexObjects.cs" />
     <Compile Include="RuntimeDataSource\BaseClass.cs" />
+    <Compile Include="RuntimeDataSource\LongPathNames.cs" />
     <Compile Include="RuntimeDataSource\SharedDataSource.cs" />
     <Compile Include="RuntimeDataSource\SimpleObjects2.cs" />
     <Compile Include="RuntimeDataSource\InheritedTests.cs" />

--- a/MSTestHacks.Tests/RuntimeDataSource/LongPathNames.cs
+++ b/MSTestHacks.Tests/RuntimeDataSource/LongPathNames.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MSTestHacks.Tests.RuntimeDataSource
+{
+    [TestClass]
+    public class LongPathNames : TestBase
+    {
+        const string PREFIX = "MSTestHacks.Tests.RuntimeDataSource.LongPathNames.";
+
+        /// <summary>
+        /// 260 Chars (Including directory) - NOTE THIS WILL CHANGE ON USERS PC..
+        /// Tested Path: C:\Git\Digital\MSTestHacks\MSTestHacks.Tests\bin\Debug\MSTestHacks\RuntimeDataSources\MSTestHacks.Tests.RuntimeDataSource.LongPathNames.  +  PropertyName
+        /// </summary>
+        public IEnumerable<int> XXXXXX_12ataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataData
+        {
+            get
+            {
+                return new List<int> { 1, 2, 3 };
+            }
+        }
+
+        /// <summary>
+        /// 261 Chars (Including directory) - NOTE THIS WILL CHANGE ON USERS PC..
+        /// Tested Path: C:\Git\Digital\MSTestHacks\MSTestHacks.Tests\bin\Debug\MSTestHacks\RuntimeDataSources\MSTestHacks.Tests.RuntimeDataSource.LongPathNames.  +  PropertyName
+        /// </summary>
+        public IEnumerable<int> XXXXXXX_12ataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataData
+        {
+            get
+            {
+                return new List<int> { 4, 5, 6 };
+            }
+        }
+
+        /// <summary>
+        /// 259 Chars (Including directory) - NOTE THIS WILL CHANGE ON USERS PC..
+        /// Tested Path: C:\Git\Digital\MSTestHacks\MSTestHacks.Tests\bin\Debug\MSTestHacks\RuntimeDataSources\MSTestHacks.Tests.RuntimeDataSource.LongPathNames.  +  PropertyName
+        /// </summary>
+        public IEnumerable<int> XXXXX_12ataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataData
+        {
+            get
+            {
+                return new List<int> { 7, 8, 9 };
+            }
+        }
+
+        [TestMethod]
+        [DataSource(PREFIX + "XXXXX_12ataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataData")]
+        public void NamesBelow255CharsShouldSucceed()
+        {
+            var value = this.TestContext.GetRuntimeDataSourceObject<int>();
+            Assert.IsTrue(value > 0);
+        }
+
+        [TestMethod]
+        [DataSource(PREFIX + "XXXXXX_12ataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataData")]
+        public void NamesWith255CharsShouldSucceed()
+        {
+            var value = this.TestContext.GetRuntimeDataSourceObject<int>();
+            Assert.IsTrue(value > 0);
+        }
+
+        [TestMethod]
+        [DataSource(PREFIX + "XXXXXXX_12ataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataDataData")]
+        public void NamesAbove255CharsShouldSucceed()
+        {
+            var value = this.TestContext.GetRuntimeDataSourceObject<int>();
+            Assert.IsTrue(value > 0);
+        }
+    }
+}

--- a/MSTestHacks/RuntimeDataSource/AttachRuntimeDataSources.cs
+++ b/MSTestHacks/RuntimeDataSource/AttachRuntimeDataSources.cs
@@ -30,11 +30,11 @@ namespace MSTestHacks.RuntimeDataSource
 
             var appConfig = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
 
-            //If the connectionStrings section doest exist, add it.
+            //If the connectionStrings section doesn't exist, add it.
             if (!appConfig.Sections.Cast<ConfigurationSection>().Any(x => x.SectionInformation.Name == "connectionStrings"))
                 appConfig.Sections.Add("connectionStrings", new ConnectionStringsSection());
 
-            //If the test tools section doest exist, add it.
+            //If the test tools section doesn't exist, add it.
             if (!appConfig.Sections.Cast<ConfigurationSection>().Any(x => x.SectionInformation.Name == "microsoft.visualstudio.testtools"))
                 appConfig.Sections.Add("microsoft.visualstudio.testtools", new Microsoft.VisualStudio.TestTools.UnitTesting.TestConfigurationSection());
 
@@ -93,7 +93,7 @@ namespace MSTestHacks.RuntimeDataSource
                     }
 
                     var connectionStringName = dataSourceName + "_RuntimeDataSource";
-                    var dataSourceFilePath = Path.Combine(DATASOURCES_PATH, dataSourceName + ".xml");
+                    var dataSourceFilePath = Path.Combine(DATASOURCES_PATH, Guid.NewGuid().ToString("N") + ".xml");
 
                     //Add connection string
                     connectionStringsSection.ConnectionStrings.Add(new ConnectionStringSettings(connectionStringName, dataSourceFilePath, "Microsoft.VisualStudio.TestTools.DataSource.XML"));
@@ -110,8 +110,12 @@ namespace MSTestHacks.RuntimeDataSource
                     testConfigurationSection.DataSources.Add(dataSource);
                     configChanged = true;
 
+                    //Create the iterations element and set the dataSourceName as an attribute for debugging.
+                    var iterationsElement = new XElement("Iterations");
+                    iterationsElement.SetAttributeValue("DataSourceName", dataSourceName);
+
                     //Create the file
-                    File.WriteAllText(dataSourceFilePath, new XDocument(new XDeclaration("1.0", "utf-8", "true"), new XElement("Iterations")).ToString());
+                    File.WriteAllText(dataSourceFilePath, new XDocument(new XDeclaration("1.0", "utf-8", "true"), iterationsElement).ToString());
 
                     //Load the file
                     var doc = XDocument.Load(dataSourceFilePath);

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ public void MethodThrowsExceptionAndTheValidatorWorks()
 
 Changelog
 ==========================================================================
+*2.3.8*
+- Fixed datasource file paths too long issues
+- 
 *2.3.1*
 - Added support for .net 40 framework
 


### PR DESCRIPTION
Made xml files have guid filenames. This limits their length and should fix issues with windows pathnames being too long. (Unless your directory structure is crazy deep)

Fix: Make pathname be GUID's which are unique. Inside the file there is a "Iterations" node that now has the datasourceName set - this is just for debugging purposes.

Fixes #13