### PR TITLE
Patch 1

### DIFF
--- a/MSTestHacks/RuntimeDataSource/AttachRuntimeDataSources.cs
+++ b/MSTestHacks/RuntimeDataSource/AttachRuntimeDataSources.cs
@@ -56,6 +56,7 @@ namespace MSTestHacks.RuntimeDataSource
             //BUG: Other DLL's are not loaded into this app domain as its happening too early. We need to change this to
             //search the directory or something similar.
             var assembliesToSearch = AppDomain.CurrentDomain.GetAssemblies()
+                                                            .Where(a => !a.FullName.ToLowerInvariant().StartsWith("microsoft"))
                                                             .SelectMany(assembly => assembly.GetTypes())
                                                             .Select(x => x.Assembly)
                                                             .Distinct();


### PR DESCRIPTION
This was what I needed to get MSTestHacks to work with mstest.console.exe. I had to copy mstest.console.exe, mstest.console.exe.config and Microsoft.VisualStudio.QualityTools.CodedUITestFramework.dll to the build directory (I had disabled deployment). Nice tool, thanks.