### PR TITLE
Added the ability to exclude data sources using a app.config ExclusionRegEx setting

### DIFF
--- a/MSTestHacks.Tests/App.config
+++ b/MSTestHacks.Tests/App.config
@@ -2,4 +2,9 @@
 <configuration>
   <!--This needs to exist for MSTestHacks to dynamically add the 
       datasources (Unless your running as administrator)-->
+
+  <appSettings>
+    <!-- Below is an example of usage for ExclusionRegEx -->
+    <!--<add key="ExclusionRegEx" value=".Exclusions.PublicProperty"/>-->
+  </appSettings>
 </configuration>

--- a/MSTestHacks.Tests/Asserts/ExceptionAssertTests.cs
+++ b/MSTestHacks.Tests/Asserts/ExceptionAssertTests.cs
@@ -66,7 +66,7 @@ namespace MSTestHacks.Tests.Asserts
             {
                 ExceptionAssert.Throws<Exception>(() => method("some param"), x => x.Message == "This is silly");
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Assert.IsTrue(ex.Message.Contains("Validator for expected exception failed."));
             }

--- a/MSTestHacks.Tests/MSTestHacks.Tests.csproj
+++ b/MSTestHacks.Tests/MSTestHacks.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Asserts\ExceptionAssertTests.cs" />
     <Compile Include="RuntimeDataSource\ComplexObjects.cs" />
     <Compile Include="RuntimeDataSource\BaseClass.cs" />
+    <Compile Include="RuntimeDataSource\Exclusions.cs" />
     <Compile Include="RuntimeDataSource\LongPathNames.cs" />
     <Compile Include="RuntimeDataSource\SharedDataSource.cs" />
     <Compile Include="RuntimeDataSource\SimpleObjects2.cs" />

--- a/MSTestHacks.Tests/RuntimeDataSource/Exclusions.cs
+++ b/MSTestHacks.Tests/RuntimeDataSource/Exclusions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MSTestHacks.RuntimeDataSource;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using System.Xml;
+using System.Linq;
+
+namespace MSTestHacks.Tests.RuntimeDataSource
+{
+    [TestClass]
+    public class Exclusions : TestBase
+    {
+        const string PREFIX = "MSTestHacks.Tests.RuntimeDataSource.Exclusions.";
+
+        public IEnumerable<int> PublicProperty { get { return new[] { 1, 2, 3, 4, 5 }; } }
+
+        [TestMethod]
+        [DataSource(PREFIX + "PublicProperty")]
+        public void Exclusions_ExcludedProperty_GeneratesDataSourceNotFoundError()
+        {
+            //After uncommenting out the app.config ExclusionRegEx key this test should fail with a
+            //Data source 'xxxxxxx' cannot be found in the test configuration settings error
+            var x = this.TestContext.GetRuntimeDataSourceObject<int>();
+            Assert.IsTrue(x > 0);
+        }
+    }
+}


### PR DESCRIPTION
Having the ability to conditionally exclude large data source would be a useful feature to have in MSTestHacks.  Using RegEx gives the power to exclude datasources 'by name' based on complex expressions. A test has been written but it is a conditional one to run 'that fails' after adjusting the app.config setting.